### PR TITLE
raise an exception if sndfile is not found

### DIFF
--- a/doc/fake__soundfile.py
+++ b/doc/fake__soundfile.py
@@ -1,5 +1,10 @@
 """Mock module for Sphinx autodoc."""
 
+import ctypes
+
+# Monkey-patch ctypes to disable searching for libsndfile
+ctypes.util.find_library = lambda _: NotImplemented
+
 
 class ffi(object):
 

--- a/soundfile.py
+++ b/soundfile.py
@@ -137,7 +137,10 @@ _ffi_types = {
 }
 
 try:
-    _snd = _ffi.dlopen(_find_library('sndfile'))
+    _libname = _find_library('sndfile')
+    if _libname is None:
+        raise OSError('sndfile library not found')
+    _snd = _ffi.dlopen(_libname)
 except OSError:
     if _sys.platform == 'darwin':
         _libname = 'libsndfile.dylib'


### PR DESCRIPTION
ctypes find_library will simply return None if the library is not
found and passing this to ffi.dlopen will cause it to return stdlib
without error which is absolutely not what we want. This commit just
raises an exception if find_library returns None.

this also monkey patches ctypes find_library to disable searching
whenever building documentation