### PR TITLE
Build script improvements

### DIFF
--- a/build_wheels.py
+++ b/build_wheels.py
@@ -1,23 +1,14 @@
 import os
-import shutil
 
-architectures = dict(darwin=['64bit'],
-                     win32=['32bit', '64bit'],
-                     noplatform='noarch')
-
-def cleanup():
-    shutil.rmtree('build', ignore_errors=True)
-    try:
-        os.remove('_soundfile.py')
-    except:
-        pass
-
-for platform, archs in architectures.items():
+def make_wheel(platform, arch, dist):
+    os.system('python setup.py clean --all')
     os.environ['PYSOUNDFILE_PLATFORM'] = platform
-    for arch in archs:
-        os.environ['PYSOUNDFILE_ARCHITECTURE'] = arch
-        cleanup()
-        os.system('python setup.py bdist_wheel')
+    os.environ['PYSOUNDFILE_ARCHITECTURE'] = arch
+    os.system(f'python setup.py {dist}')
 
-cleanup()
-os.system('python setup.py sdist')
+if __name__ == '__main__':
+    make_wheel('darwin', '64bit', 'bdist_wheel')
+    make_wheel('win32', '32bit', 'bdist_wheel')
+    make_wheel('win32', '64bit', 'bdist_wheel')
+    make_wheel('', '', 'bdist_wheel')
+    make_wheel('', '', 'sdist')

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,13 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
 
+for line in open('soundfile.py'):
+    if line.startswith('__version__'):
+        exec(line)
+        break
+else:
+    raise RuntimeException('No version number found')
+
 PYTHON_INTERPRETERS = '.'.join([
     'cp26', 'cp27',
     'cp32', 'cp33', 'cp34', 'cp35', 'cp36',
@@ -87,7 +94,7 @@ else:
 
 setup(
     name='SoundFile',
-    version='0.10.1',
+    version=__version__,
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',


### PR DESCRIPTION
Referring back to #220, we need to improve our build process.

Right now, we *should* be building correct cross-platform wheels.

However, the source distribution currently includes all binaries, which is not intended.

Also, there is currently no deprecation notice for *Py*SoundFile.