### PR TITLE
Test garbage collectability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "nightly"
-  - "pypy-5.3.1"
-  - "pypy-5.4.1"
-  # TODO: Enable pypy3 once NumPy is working there, see
-  # https://bitbucket.org/pypy/pypy/issues/1567/
+  - "pypy"
+  # TODO: Enable pypy3 once NumPy is working there, see	
+  # https://bitbucket.org/pypy/pypy/issues/1567/	
   #- "pypy3"
 addons:
   apt:
     packages:
     - libsndfile1
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then pip install git+https://bitbucket.org/pypy/numpy.git ; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then pip install git+https://bitbucket.org/pypy/numpy.git ; fi"
 script:
   - python setup.py test

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -6,6 +6,8 @@ import shutil
 import pytest
 import cffi
 import sys
+import gc
+import weakref
 
 # floating point data is typically limited to the interval [-1.0, 1.0],
 # but smaller/larger values are supported as well
@@ -888,6 +890,14 @@ def test_anything_on_closed_file(file_stereo_r):
     with pytest.raises(RuntimeError) as excinfo:
         f.seek(0)
     assert "closed" in str(excinfo.value)
+
+
+def test_garbage(file_stereo_r):
+    f = sf.SoundFile(file_stereo_r)
+    ref = weakref.ref(f)
+    f = None
+    gc.collect()
+    assert ref() is None
 
 
 def test_file_attributes_should_save_to_disk(file_w):


### PR DESCRIPTION
When out of scope, SoundFile should vanish.

Explicit `gc.collect()` is required for this to pass in PyPy 7.0.0, but not in CPython 2.7.15+ or 3.6.8.