### PR TITLE
Fix sf_open error checking when used concurrently

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1181,8 +1181,10 @@ class SoundFile(object):
                                             mode_int, self._info, _ffi.NULL)
         else:
             raise TypeError("Invalid file: {0!r}".format(self.name))
-        _error_check(_snd.sf_error(file_ptr),
-                     "Error opening {0!r}: ".format(self.name))
+        if file_ptr == _ffi.NULL:
+            # get the actual error code
+            err = _snd.sf_error(file_ptr)
+            raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         if mode_int == _snd.SFM_WRITE:
             # Due to a bug in libsndfile version <= 1.0.25, frames != 0
             # when opening a named pipe in SFM_WRITE mode.
@@ -1538,8 +1540,13 @@ class LibsndfileError(SoundFileRuntimeError):
     @property
     def error_string(self):
         """Raw libsndfile error message."""
-        err_str = _snd.sf_error_number(self.code)
-        return _ffi.string(err_str).decode('utf-8', 'replace')
+        if self.code:
+            err_str = _snd.sf_error_number(self.code)
+            return _ffi.string(err_str).decode('utf-8', 'replace')
+        else:
+            # Due to race conditions, if used concurrently, sf_error() may
+            # return 0 (= no error) even if an error has happened.
+            return "(Garbled error message from libsndfile)"
 
     def __str__(self):
         return self.prefix + self.error_string

--- a/soundfile.py
+++ b/soundfile.py
@@ -1546,6 +1546,7 @@ class LibsndfileError(SoundFileRuntimeError):
         else:
             # Due to race conditions, if used concurrently, sf_error() may
             # return 0 (= no error) even if an error has happened.
+            # See https://github.com/erikd/libsndfile/issues/610 for details.
             return "(Garbled error message from libsndfile)"
 
     def __str__(self):

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -765,7 +765,7 @@ def test_concurren_open_error_reporting(file_inmemory):
         for _ in range(n_trials_per_thread):
             try:
                 sf.SoundFile(file_inmemory)
-            except Exception as e:
+            except sf.LibsndfileError:
                 n_reported_errors += 1
 
     threads = [threading.Thread(target=target) for _ in range(n_threads)]

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -8,6 +8,7 @@ import cffi
 import sys
 import gc
 import weakref
+import threading
 
 # floating point data is typically limited to the interval [-1.0, 1.0],
 # but smaller/larger values are supported as well
@@ -749,6 +750,30 @@ def test_read_into_out_over_end_with_fill_should_return_full_data_and_write_into
     assert np.all(data == out)
     assert np.all(data[2:] == 0)
     assert out.shape == (4, sf_stereo_r.channels)
+
+def test_concurren_open_error_reporting(file_inmemory):
+    # Test that no sf_open errors are missed when pysoundfile is used
+    # concurrently (there are race conditions in libsndfile's error reporting).
+
+    n_threads = 4
+    n_trials_per_thread = 10
+
+    n_reported_errors = 0
+
+    def target():
+        nonlocal n_reported_errors
+        for _ in range(n_trials_per_thread):
+            try:
+                sf.SoundFile(file_inmemory)
+            except Exception as e:
+                n_reported_errors += 1
+
+    threads = [threading.Thread(target=target) for _ in range(n_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert n_reported_errors == n_threads * n_trials_per_thread
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -758,22 +758,21 @@ def test_concurren_open_error_reporting(file_inmemory):
     n_threads = 4
     n_trials_per_thread = 10
 
-    n_reported_errors = 0
+    n_reported_errors = [0]
 
     def target():
-        nonlocal n_reported_errors
         for _ in range(n_trials_per_thread):
             try:
                 sf.SoundFile(file_inmemory)
             except sf.LibsndfileError:
-                n_reported_errors += 1
+                n_reported_errors[0] += 1
 
     threads = [threading.Thread(target=target) for _ in range(n_threads)]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
-    assert n_reported_errors == n_threads * n_trials_per_thread
+    assert n_reported_errors[0] == n_threads * n_trials_per_thread
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
libsndfile error reporting is not thread safe, see https://github.com/erikd/libsndfile/issues/279 https://github.com/erikd/libsndfile/issues/610.

The patch does not attempt to fix that, but it changes the way errors are checked for in order to fix one specific race condition:

If opening a file not understood by libsndfile with `sf.SoundFile`, and then attempting to `.read()` from it, sometimes opening the file with `sf.SoundFile` does not report an error (due to the libsndfile race condition), and then the `.read()` fails. (As a consequence, librosa will not attempt to open the file using `audioread`, making `librosa.load` fail.)